### PR TITLE
Fix crash and improve public API

### DIFF
--- a/Sources/TabbyController.swift
+++ b/Sources/TabbyController.swift
@@ -124,6 +124,7 @@ public class TabbyController: UIViewController {
   public override func viewDidAppear(animated: Bool) {
     super.viewDidAppear(animated)
 
+    guard tabbyBar.selectedIndex < controllers.count else { return }
     tabbyBar.indicator.center.x = tabbyBar.buttons[tabbyBar.selectedIndex].center.x
   }
 

--- a/Sources/TabbyController.swift
+++ b/Sources/TabbyController.swift
@@ -109,6 +109,12 @@ public class TabbyController: UIViewController {
     setupConstraints()
   }
 
+  public convenience init(controllers controllers: [(controller: UIViewController, image: UIImage?)]) {
+    self.init(nibName: nil, bundle: nil)
+
+    self.controllers = controllers
+  }
+
   /**
    Initializer.
    */


### PR DESCRIPTION
This PR adds a convenience init to instantiate Tabby with a set of tuple controllers.

It also fixes a crash that occurs if you init without any controllers, the reason for the crash was that it tried to access an index that clearly didn’t exist.
