### PR TITLE
Set zPosition to show separator and indicator on top

### DIFF
--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -30,6 +30,7 @@ open class TabbyBar: UIView {
 
   lazy var indicator: UIView = {
     let view = UIView()
+    view.layer.zPosition = 2
     view.backgroundColor = Constant.Color.indicator
 
     return view

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -38,6 +38,7 @@ open class TabbyBar: UIView {
   lazy var separator: UIView = {
     let view = UIView()
     view.backgroundColor = Constant.Color.separator
+    view.layer.zPosition = 1
 
     return view
   }()


### PR DESCRIPTION
The separator was not showing because it was below the collection view. Setting `zPosition` on the layer fixes the issue.
