### PR TITLE
Add guard in viewDidAppear

### DIFF
--- a/Sources/TabbyController.swift
+++ b/Sources/TabbyController.swift
@@ -196,6 +196,10 @@ open class TabbyController: UIViewController, UINavigationControllerDelegate {
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
 
+    guard childViewControllers.isEmpty else {
+      return
+    }
+
     tabbyButtonDidPress(index)
   }
 


### PR DESCRIPTION
Add guard to only call tabbyButtonDidPress in viewDidAppear if it has no child view controllers.

I believe this method is invoked to programmatically tap the current tab bar to setup the view controller at that index. However, we don't want to do this every time the tabby controller appears on screen. To avoid this, we only call that method if there are no child view controllers in TabbyController.