### PR TITLE
Trying to fix reload

### DIFF
--- a/Demo/TabbyDemo/TabbyDemo/AppDelegate.swift
+++ b/Demo/TabbyDemo/TabbyDemo/AppDelegate.swift
@@ -1,6 +1,18 @@
 import UIKit
 import Tabby
 
+class MainController: TabbyController {
+  override init(items: [TabbyBarItem]) {
+    super.init(items: items)
+
+    setIndex = 1
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError()
+  }
+}
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -10,8 +22,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     TabbyBarItem(controller: self.thirdNavigation, image: "fish")
   ]
 
-  lazy var mainController: TabbyController = { [unowned self] in
-    let controller = TabbyController(items: self.items)
+  lazy var mainController: MainController = { [unowned self] in
+    let controller = MainController(items: self.items)
 
     controller.delegate = self
     controller.translucent = false

--- a/Demo/TabbyDemo/TabbyDemo/AppDelegate.swift
+++ b/Demo/TabbyDemo/TabbyDemo/AppDelegate.swift
@@ -2,14 +2,10 @@ import UIKit
 import Tabby
 
 class MainController: TabbyController {
-  override init(items: [TabbyBarItem]) {
-    super.init(items: items)
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
 
     setIndex = 1
-  }
-
-  required init?(coder aDecoder: NSCoder) {
-    fatalError()
   }
 }
 

--- a/Sources/Cells/TabbyCell.swift
+++ b/Sources/Cells/TabbyCell.swift
@@ -44,10 +44,6 @@ open class TabbyDefaultCell: UICollectionViewCell, TabbyCell {
     label.text = item.controller.title
     label.textColor = color
 
-    if selected {
-      Constant.tapItemAnimation(imageView)
-    }
-
     handleBadge(count)
     handleBehaviors(selected)
     setupConstraints()

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -51,7 +51,6 @@ open class TabbyBar: UIView {
   var selectedItem: Int = 0 {
     didSet {
       positionIndicator(selectedItem)
-      collectionView.reloadData()
     }
   }
 

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -99,17 +99,20 @@ open class TabbyBar: UIView {
   // Animations
 
   func positionIndicator(_ index: Int, animate: Bool = true) {
-    guard let source = collectionView.dataSource , index < items.count else { return }
+    guard collectionView.dataSource != nil,
+      index < items.count else {
+        return
+    }
 
-    let x = source.collectionView(
-      self.collectionView,
-      cellForItemAt: IndexPath(row: index, section: 0)
-    ).center.x
+    let indexPath = IndexPath(row: index, section: 0)
+    guard let cell = collectionView.cellForItem(at: indexPath) else {
+      return
+    }
 
     UIView.animate(
       withDuration: animate ? 0.7 : 0, delay: 0, usingSpringWithDamping: 0.6,
       initialSpringVelocity: 0, options: [.curveEaseIn], animations: {
-        self.indicator.center.x = x
+        self.indicator.center.x = cell.center.x
     }, completion: nil)
   }
 

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -162,6 +162,25 @@ open class TabbyBar: UIView {
     addSubview(collectionView)
     constraint(collectionView, attributes: .top, .bottom, .leading, .trailing)
   }
+
+  // MAKR: - Selection
+
+  /// Handle selection on a cell
+  /// This call Constant.tapItemAnimation on the found UIImageView by default.
+  ///
+  /// - Parameter indexPath: The indexPath of the selected cell
+  open func handleSelection(indexPath: IndexPath) {
+    guard let cell = collectionView.cellForItem(at: indexPath) else {
+      return
+    }
+
+    guard let imageView = cell.contentView.subviews
+      .flatMap({ $0 as? UIImageView }).first else {
+      return
+    }
+
+    Constant.tapItemAnimation(imageView)
+  }
 }
 
 extension TabbyBar: UICollectionViewDelegate {
@@ -178,6 +197,7 @@ extension TabbyBar: UICollectionViewDelegate {
       selectedItem = position
     }
 
+    handleSelection(indexPath: indexPath)
     delegate?.tabbyButtonDidPress(position)
   }
 }

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -13,9 +13,6 @@ public protocol TabbyBarDelegate: class {
  */
 open class TabbyBar: UIView {
 
-  static let collectionObserver = "contentSize"
-  static let KVOContext = UnsafeMutableRawPointer(mutating: nil)
-
   lazy var translucentView: UIVisualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
 
   lazy var layout: TabbyLayout = {
@@ -77,22 +74,8 @@ open class TabbyBar: UIView {
 
     backgroundColor = .clear
 
-    collectionView.addObserver(
-      self, forKeyPath: TabbyBar.collectionObserver,
-      options: .old, context: TabbyBar.KVOContext)
-
     setupCollectionView()
     setupConstraints()
-  }
-
-  open override func observeValue(
-    forKeyPath keyPath: String?, of object: Any?,
-    change: [NSKeyValueChangeKey : Any]?,
-    context: UnsafeMutableRawPointer?) {
-    guard context == TabbyBar.KVOContext else {
-      return
-    }
-    positionIndicator(selectedItem, animate: false)
   }
 
   /**
@@ -100,10 +83,6 @@ open class TabbyBar: UIView {
    */
   public required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  deinit {
-    collectionView.removeObserver(self, forKeyPath: TabbyBar.collectionObserver)
   }
 
   // MARK: - Collection View setup

--- a/Sources/Views/TabbyBar.swift
+++ b/Sources/Views/TabbyBar.swift
@@ -101,11 +101,15 @@ open class TabbyBar: UIView {
   func positionIndicator(_ index: Int, animate: Bool = true) {
     guard let source = collectionView.dataSource , index < items.count else { return }
 
+    let x = source.collectionView(
+      self.collectionView,
+      cellForItemAt: IndexPath(row: index, section: 0)
+    ).center.x
+
     UIView.animate(
       withDuration: animate ? 0.7 : 0, delay: 0, usingSpringWithDamping: 0.6,
       initialSpringVelocity: 0, options: [.curveEaseIn], animations: {
-        self.indicator.center.x = source.collectionView(
-          self.collectionView, cellForItemAt: IndexPath(row: index, section: 0)).center.x
+        self.indicator.center.x = x
     }, completion: nil)
   }
 


### PR DESCRIPTION
- Remove unnecessary `contentSize` observations
- Do not perform cell tap animation inside configure, call it when the cell is tapped
- Remove call to `reloadData`, this causes cells to jump of and down. Also, the whole collectionView is fade in. I don't know why